### PR TITLE
docs(core/react) Примеры использования при TS v5+

### DIFF
--- a/packages/core/src/types/common.ts
+++ b/packages/core/src/types/common.ts
@@ -15,6 +15,16 @@
  *  type UnknownValueType = (typeof eventData)['anyFieldYouWant'] // Compilation Error
  * })
  *
+ * @example
+ * // При использовании Typescript v5+ может потребоваться доопределение модуля по прямому пути
+ * import '@vkontakte/mini-apps-analytics/dist/types/src/types/common';
+ * // Важно доопределять конкретный файл
+ * declare module '@vkontakte/mini-apps-analytics/dist/types/src/types/common' {
+ *     export interface CustomData {
+ *         myAwesomeValue: string
+ *     }
+ * }
+ *
  */
 /* Эксопртируем пустой интерфейс для дальнейшего расширения с помощью module augmentation */
 /* eslint-disable-next-line @typescript-eslint/no-empty-interface */

--- a/packages/react/example/analytics.example.tsx
+++ b/packages/react/example/analytics.example.tsx
@@ -24,6 +24,13 @@ import {
 import React, { PropsWithChildren, useEffect, useMemo, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 
+/*
+* В случае Typescript v5+
+* import '@vkontakte/mini-apps-analytics/dist/types/src/types/common';
+* declare module '@vkontakte/mini-apps-analytics/dist/types/src/types/common' {...}
+*
+* */
+
 declare module '@vkontakte/mini-apps-analytics' {
    export interface CustomData {
    myAwesomeStringAppData: string;


### PR DESCRIPTION
- docs(core) Обновил пример использования доопределения CustomData в случае TS v5+
- docs(react) добавил информацию о использовании в случае TS v5+